### PR TITLE
Proposition of ticket template for Libero

### DIFF
--- a/.github/ISSUE_TEMPLATE/ticket_template1.md
+++ b/.github/ISSUE_TEMPLATE/ticket_template1.md
@@ -1,7 +1,7 @@
-🚨Please review the [guidelines for feature ticket](../HOWTOWRITEATICKETS.md) to this repository if unsure about what to write..
+🚨Please review the [guidelines for feature ticket](../HOWTOWRITEATICKETS.md) to this repository if unsure about what to write.
 
 +## Problem / Motivation
-Describe your issue here. You can you the user story format.
+Describe your issue here. You can use the user story format.
 - As a ... Who?
 - I would like ... what?
 - So that ... why?

--- a/.github/ISSUE_TEMPLATE/ticket_template1.md
+++ b/.github/ISSUE_TEMPLATE/ticket_template1.md
@@ -5,18 +5,18 @@
 - WHAT do they want?
 - WHY do they want this?
 
-## Proposed solution and tasks
+## Proposed solution
 <!-- Describe the solution here and list the tasks required -->
 - Is like this 
 - And like this
 
+## Tasks
 <!-- List of tasks for this ticket to be complete -->
-To do list:
 - [ ] A descriptive of a task
 - [ ] A description
 
 ## Clarification needed and assumptions
-<!-- Write any questions you might have or assumptions that could help other contributors to understand the context within wich the ticket was written -->
+<!-- Write any questions you might have or assumptions that could help other contributors to understand the context within which the ticket was written -->
 - A question
 - An assumption
 

--- a/.github/ISSUE_TEMPLATE/ticket_template1.md
+++ b/.github/ISSUE_TEMPLATE/ticket_template1.md
@@ -7,7 +7,11 @@
 
 ## Proposed solution and tasks
 <!-- Describe the solution here and list the tasks required -->
-List of tasks for this ticket to be complete:
+- Is like this 
+- And like this
+
+<!-- List of tasks for this ticket to be complete -->
+To do list:
 - [ ] A descriptive of a task
 - [ ] A description
 

--- a/.github/ISSUE_TEMPLATE/ticket_template1.md
+++ b/.github/ISSUE_TEMPLATE/ticket_template1.md
@@ -16,12 +16,12 @@ List of tasks for this ticket to be complete:
 
 +## Clarification needed
 These questions or assumptions need to be answered for a developer to complete this ticket. Delete this section if everything is clear.
-- [ ] A descriptive of a task
-- [ ] A description
+- [ ] A question
+- [ ] An assumption that needs to be confirmed
 
 +## Technical notes
 - We could use this technology 
 - More notes or suggestions
 
 +## User interface / Wireframes
-Include wireframes if relevant.
+Include any useful sketch, wireframes, screenshot if relevant.

--- a/.github/ISSUE_TEMPLATE/ticket_template1.md
+++ b/.github/ISSUE_TEMPLATE/ticket_template1.md
@@ -1,0 +1,27 @@
+🚨Please review the [guidelines for feature ticket](../HOWTOWRITEATICKETS.md) to this repository if unsure about what to write..
+
++## Problem / Motivation
+Describe your issue here. You can you the user story format.
+- As a ... Who?
+- I would like ... what?
+- So that ... why?
+
+
++## Proposed solution and tasks
+We could build this.... and it will solve that...
+
+List of tasks for this ticket to be complete:
+- [ ] A descriptive of a task
+- [ ] A description
+
++## Clarification needed
+These questions or assumptions need to be answered for a developer to complete this ticket. Delete this section if everything is clear.
+- [ ] A descriptive of a task
+- [ ] A description
+
++## Technical notes
+- We could use this technology 
+- More notes or suggestions
+
++## User interface / Wireframes
+Include wireframes if relevant.

--- a/.github/ISSUE_TEMPLATE/ticket_template1.md
+++ b/.github/ISSUE_TEMPLATE/ticket_template1.md
@@ -12,7 +12,7 @@ List of tasks for this ticket to be complete:
 - [ ] A description
 
 ## Clarification needed and assumptions
-<!-- List any questions for stakeholders you might have or assumptions that could help other contributors to understand the context within wich the ticket was written -->
+<!-- Write any questions you might have or assumptions that could help other contributors to understand the context within wich the ticket was written -->
 - A question
 - An assumption
 

--- a/.github/ISSUE_TEMPLATE/ticket_template1.md
+++ b/.github/ISSUE_TEMPLATE/ticket_template1.md
@@ -1,27 +1,24 @@
-🚨Please review the [guidelines for ticket creation](../HOWTOWRITEATICKETS.md) if needed
-
 ## Problem / Motivation
-Describe your issue here. You can use the user story format.
-- As a ... Who?
-- I would like ... what?
-- So that ... why?
-
+<!-- Describe the problem here using the 5Ws. You can use the user story format: As a [Who] and [When][Where] I would like [What] so that [Why] --> 
+- WHO wants this?
+- WHEN and WHERE do they want it?
+- WHAT do they want?
+- WHY do they want this?
 
 ## Proposed solution and tasks
-We could build this.... and it will solve that...
-
+<!-- Describe the solution here and list the tasks required -->
 List of tasks for this ticket to be complete:
 - [ ] A descriptive of a task
 - [ ] A description
 
-## Clarification needed
-These questions or assumptions need to be answered for a developer to complete this ticket. Delete this section if everything is clear.
-- [ ] A question
-- [ ] An assumption that needs to be confirmed
+## Clarification needed and assumptions
+<!-- List any questions for stakeholders you might have or assumptions that could help other contributors to understand the context within wich the ticket was written -->
+- A question
+- An assumption
 
 ## Technical notes
 - We could use this technology 
 - More notes or suggestions
 
 ## User interface / Wireframes
-Include any useful sketch, wireframes, screenshot if relevant.
+<!-- Include any useful sketch, wireframes, screenshot if relevant. -->

--- a/.github/ISSUE_TEMPLATE/ticket_template1.md
+++ b/.github/ISSUE_TEMPLATE/ticket_template1.md
@@ -1,27 +1,27 @@
-🚨Please review the [guidelines for feature ticket](../HOWTOWRITEATICKETS.md) to this repository if unsure about what to write.
+🚨Please review the [guidelines for ticket creation](../HOWTOWRITEATICKETS.md) if needed
 
-+## Problem / Motivation
+## Problem / Motivation
 Describe your issue here. You can use the user story format.
 - As a ... Who?
 - I would like ... what?
 - So that ... why?
 
 
-+## Proposed solution and tasks
+## Proposed solution and tasks
 We could build this.... and it will solve that...
 
 List of tasks for this ticket to be complete:
 - [ ] A descriptive of a task
 - [ ] A description
 
-+## Clarification needed
+## Clarification needed
 These questions or assumptions need to be answered for a developer to complete this ticket. Delete this section if everything is clear.
 - [ ] A question
 - [ ] An assumption that needs to be confirmed
 
-+## Technical notes
+## Technical notes
 - We could use this technology 
 - More notes or suggestions
 
-+## User interface / Wireframes
+## User interface / Wireframes
 Include any useful sketch, wireframes, screenshot if relevant.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+...coming soon


### PR DESCRIPTION
I have looked at other templates on github. The drupal one is interesting. Here is my proposition of template for the Libero MVP tickets. It would be great if we could come up with a consensus before Friday's workshop. I have tried to create a template that achieves the following goals:

1) **Easily understood by technical and non-technical stakeholders**. That means using existing industry standards and widely used terminology.

2) **Less is more.** A template as simple as possible with as few sections as possible. Additional info can be added in a How To readme.

3) **A tool to prompt discussions**. We need an easy way for a technical and non-technical stakeholder to view and add questions. Pending clarification questions should be clearly identified too and now hidden in an endless thread of comments.

The thinking behind these goals is that, according to my experience, the most successful tech projects or products are the ones that manage to get all the stakeholder highly involved. In order to do that we need transparency and easy ways for them to interact with us. For example, someone at IJM should be able to effortlessly understand what we are currently building and shouldn't be scared by a ticket because it is too technical or not welcoming. A scared stakeholder doesn't get involved. 

@nlisgo @seanwiseman @davidcmoulton (I am tagging you because you are not currently watching this repo)